### PR TITLE
Only sends the continuous WakeOnLan signal when Kodi is playing something

### DIFF
--- a/default.py
+++ b/default.py
@@ -62,6 +62,7 @@ def main(is_autostart=False):
     continuousWol = True if addon.getSetting("continuousWol").lower() == 'true' else False
     continuousWolDelay = int(addon.getSetting("continuousWolDelay"))
     continuousWolAfterStandby = True if addon.getSetting("continuousWolAfterStandby").lower() == 'true' else False
+    continuousWolOnlyWhilePlaying = True if addon.getSetting("continuousWolOnlyWhilePlaying").lower() == 'true' else False
     updateVideoLibraryAfterWol = True if addon.getSetting("updateVideoLibraryAfterWol").lower() == 'true' else False
     updateMusicLibraryAfterWol = True if addon.getSetting("updateMusicLibraryAfterWol").lower() == 'true' else False
     libraryUpdatesDelay = int(addon.getSetting("libraryUpdatesDelay"))
@@ -203,10 +204,12 @@ def main(is_autostart=False):
                 previousTime = int(time.time())
                 xbmc.sleep(1000)
                 if countingSeconds == continuousWolDelay:
-                    xbmc.executebuiltin('WakeOnLan("%s")' % macAddress)
-                    xbmc.log('[{} {}]: WakeOnLan signal sent to MAC-Address {}'.format(addon_id, version, macAddress),
-                             xbmc.LOGDEBUG)
-                    countingSeconds = 0
+
+                    if (not continuousWolOnlyWhilePlaying) or xbmc.Player().isPlaying():
+                        xbmc.executebuiltin('WakeOnLan("%s")' % macAddress)
+                        xbmc.log('[{} {}]: WakeOnLan signal sent to MAC-Address {}'.format(addon_id, version, macAddress),
+                                xbmc.LOGDEBUG)
+                        countingSeconds = 0
                 else:
                     countingSeconds += 1
 

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -133,6 +133,10 @@ msgctxt "#53023"
 msgid "Continue sending after Kodi returns from standby"
 msgstr "Sende dauerhaft nach der Rückkehr aus dem Standby"
 
+msgctxt "#53024"
+msgid "Send only while Kodi is playing something"
+msgstr "Sende nur wenn Kodi etwas abspielt"
+
 msgctxt "#60000"
 msgid "Waking up %s..."
 msgstr "Wecke %s..."

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -133,6 +133,10 @@ msgctxt "#53023"
 msgid "Continue sending after Kodi returns from standby"
 msgstr ""
 
+msgctxt "#53024"
+msgid "Send only while Kodi is playing something"
+msgstr ""
+
 msgctxt "#60000"
 msgid "Waking up %s..."
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -36,5 +36,6 @@
 		<setting id="continuousWol" type="bool" label="53021" default="false" />
 		<setting id="continuousWolDelay" type="labelenum" label="53022" values="10|20|30|40|50|60|120|180|240" default="30" enable="eq(-1,true)" />
 		<setting id="continuousWolAfterStandby" type="bool" label="53023" default="true" enable="eq(-2,true)" />
+	    <setting id="continuousWolOnlyWhilePlaying" type="bool" label="53024" default="false" enable="eq(-3,true)" />
 	</category>
 </settings>


### PR DESCRIPTION
I'm running Kodi on Android TV 9 on a Sony tv and use the WoL addon to wake up my media server and to keep it awake. 

It looks like the tv keeps Kodi in the background even when I turn the tv off. So it never stops sending WoL signals. With this new option the addon will only send its signals while Kodi is playing something.